### PR TITLE
docs: rewrite READMEs with correct import paths, clean up chat example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,146 +1,63 @@
 # socketio
 
-A copy of github.com/googollee/go-socket.io renamed with defects fixed and updated to 1.4.5 of socket.io.
-Updated to work with socket.io version 2.3.0 and jQuery 3.5.1.
+[![Go Reference](https://pkg.go.dev/badge/github.com/taigrr/socketio.svg)](https://pkg.go.dev/github.com/taigrr/socketio)
 
-socketio is an implementation of [socket.io](http://socket.io) in Go (golang).
-This provides the ability to perform real time communication from a browser
-to a server and back.  Content can be pushed from the server out to
-the browser.
+A Go (golang) implementation of [socket.io](https://socket.io), compatible with socket.io version 2.3.0.
+Supports rooms, namespaces, and real-time bidirectional browser-server communication.
 
-It is compatible with the 2.3.0 version of socket.io in Node.js, and supports room and namespace.
+Originally forked from [googollee/go-socket.io](https://github.com/googollee/go-socket.io) with
+defect fixes, import cleanup, and dependency modernization.
 
 ## Install
 
-Install the package with:
-
 ```bash
-	go get github.com/mlsquires/socketio
-	go get github.com/pschlump/godebug
-	go get github.com/pschlump/MiscLib
-```
-
-Import it with:
-
-```go
-	import "github.com/mlsquires/socketio"
+go get github.com/taigrr/socketio
 ```
 
 ## Example
 
-Please check the ./examples/chat directory for more comprehensive examples.
+See the [examples/chat](./examples/chat) directory for a full working chat server.
 
 ```go
-	package main
+package main
 
-	//
-	// Command line arguments can be used to set the IP address that is listened to and the port.
-	//
-	// $ ./chat --port=8080 --host=127.0.0.1
-	//
-	// Bring up a pair of browsers and chat between them.
-	//
+import (
+	"fmt"
+	"log"
+	"net/http"
 
-	import (
-		"flag"
-		"fmt"
-		"log"
-		"net/http"
-		"os"
+	"github.com/taigrr/socketio"
+)
 
-		"github.com/pschlump/MiscLib"
-		"github.com/pschlump/godebug"
-		"github.com/mlsquires/socketio"
-	)
-
-	var Port = flag.String("port", "9000", "Port to listen to")                           // 0
-	var HostIP = flag.String("host", "localhost", "Host name or IP address to listen on") // 1
-	var Dir = flag.String("dir", "./asset", "Direcotry where files are served from")      // 1
-	func init() {
-		flag.StringVar(Port, "P", "9000", "Port to listen to")                           // 0
-		flag.StringVar(HostIP, "H", "localhost", "Host name or IP address to listen on") // 1
-		flag.StringVar(Dir, "d", "./asset", "Direcotry where files are served from")     // 1
+func main() {
+	server, err := socketio.NewServer(nil)
+	if err != nil {
+		log.Fatal(err)
 	}
 
-	func main() {
-
-		flag.Parse()
-		fns := flag.Args()
-
-		if len(fns) != 0 {
-			fmt.Printf("Usage: Invalid arguments supplied, %s\n", fns)
-			os.Exit(1)
-		}
-
-		var host_ip string = ""
-		if *HostIP != "localhost" {
-			host_ip = *HostIP
-		}
-
-		// Make certain that the command line parameters are handled correctly
-		// fmt.Printf("host_ip >%s< HostIP >%s< Port >%s<\n", host_ip, *HostIP, *Port)
-
-		server, err := socketio.NewServer(nil)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		server.On("connection", func(so socketio.Socket) {
-			fmt.Printf("%sa user connected%s, %s\n", MiscLib.ColorGreen, MiscLib.ColorReset, godebug.LF())
-			so.Join("chat")
-			so.On("chat message", func(msg string) {
-				fmt.Printf("%schat message, %s%s, %s\n", MiscLib.ColorGreen, msg, MiscLib.ColorReset, godebug.LF())
-				so.BroadcastTo("chat", "chat message", msg)
-			})
-			so.On("disconnect", func() {
-				fmt.Printf("%suser disconnect%s, %s\n", MiscLib.ColorYellow, MiscLib.ColorReset, godebug.LF())
-			})
+	server.On("connection", func(so socketio.Socket) {
+		fmt.Println("a user connected")
+		so.Join("chat")
+		so.On("chat message", func(msg string) {
+			fmt.Println("chat message:", msg)
+			so.BroadcastTo("chat", "chat message", msg)
 		})
-
-		server.On("error", func(so socketio.Socket, err error) {
-			fmt.Printf("Error: %s, %s\n", err, godebug.LF())
+		so.On("disconnect", func() {
+			fmt.Println("user disconnected")
 		})
+	})
 
-		http.Handle("/socket.io/", server)
-		http.Handle("/", http.FileServer(http.Dir(*Dir)))
-		fmt.Printf("Serving on port %s, brows to http://localhost:%s/\n", *Port, *Port)
-		listen := fmt.Sprintf("%s:%s", host_ip, *Port)
-		log.Fatal(http.ListenAndServe(listen, nil))
-	}
+	server.On("error", func(so socketio.Socket, err error) {
+		fmt.Printf("error: %s\n", err)
+	})
+
+	http.Handle("/socket.io/", server)
+	http.Handle("/", http.FileServer(http.Dir("./asset")))
+	fmt.Println("serving on :9000")
+	log.Fatal(http.ListenAndServe(":9000", nil))
+}
 ```
 
 ## License
 
-The 3-clause BSD License  - see LICENSE for more details
-
-## History
-
-This code is from an original https://github.com/googollee/go-socket.io .  The following 
-have been made:
-
-1. Renamed the package so that the directory structure matches with the package name.
-Some outside tools depend on this.
-1. Included go-engine.io as a subdirectory.
-1. Fixed defect #68 - "Not Thread Safe".  All accesses to maps are synchronized.
-1. Documentation improvements.
-1. Updated to use the current version of socket.io (1.3.6)
-1. Provided a packed(uglified) version of the JavaScript scoket.io library. A non-uglified version is in the 
-same directory also.
-1. Original defect #95 - Crash occurs when too many arguments are passed - suggested fix used and tested.
-1. Fixed a set of continuous connect/disconnect problems
-1. #45 - incorrect usage - see correct usage in test/o45 - fixed.
-1. #47 - crashing on Windows - unable to reproduce with go 1.3.1 on windows 8.  Appears to be fixed by changes for #68.
-1. #83 - see example in test/o83 - fixed.
-1. #82 - see example in test/o82 - fixed.
-1. #52 - see example in test/o52 - fixed.
-1. #67 - see example in test/o67 - fixed.
-1. Identified the problem where a emit is sent from client to server and server seems to discard/ignore the emit.  This is caused by an invalid paramter and an ignored error message.  Code review for all discarded/ignored error messages in progress.
-
-## FAQ
-
-1. Why is this not a fork of the original?  A: I can't figure out how to make a fork and change the
-name of the package on github.com.   Since a variety of outside tools hurl over the "-" and ".io" in
-the directory name I just made a copy and started at the beginning.   My apologies to anybody
-that feels offended by this approach.  
-
-
+3-clause BSD — see [LICENSE](./LICENSE) for details.

--- a/engineio/README.md
+++ b/engineio/README.md
@@ -1,41 +1,32 @@
-# go-engine.io
+# engineio
 
-[![GoDoc](http://godoc.org/github.com/googollee/go-engine.io?status.svg)](http://godoc.org/github.com/googollee/go-engine.io) [![Build Status](https://travis-ci.org/googollee/go-engine.io.svg)](https://travis-ci.org/googollee/go-engine.io)
+[![Go Reference](https://pkg.go.dev/badge/github.com/taigrr/socketio/engineio.svg)](https://pkg.go.dev/github.com/taigrr/socketio/engineio)
 
-go-engine.io is the implement of engine.io in golang, which is transport-based cross-browser/cross-device bi-directional communication layer for [go-socket.io](https://github.com/googollee/go-socket.io).
+A Go implementation of [engine.io](https://github.com/socketio/engine.io), the transport layer
+for [socket.io](https://socket.io). Supports long-polling and WebSocket transports.
 
-It is compatible with node.js implement, and supported long-polling and websocket transport.
+Compatible with the Node.js engine.io implementation.
 
 ## Install
 
-Install the package with:
-
 ```bash
-go get github.com/googollee/go-engine.io
+go get github.com/taigrr/socketio/engineio
 ```
-
-Import it with:
-
-```go
-import "github.com/googollee/go-engine.io"
-```
-
-and use `engineio` as the package name inside the code.
 
 ## Example
 
-Please check example folder for details.
+See the [example](./example) directory for a working demo.
 
 ```go
 package main
 
 import (
 	"encoding/hex"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 
-	"github.com/googollee/go-engine.io"
+	"github.com/taigrr/socketio/engineio"
 )
 
 func main() {
@@ -51,7 +42,7 @@ func main() {
 				defer conn.Close()
 				for i := 0; i < 10; i++ {
 					t, r, _ := conn.NextReader()
-					b, _ := ioutil.ReadAll(r)
+					b, _ := io.ReadAll(r)
 					r.Close()
 					if t == engineio.MessageText {
 						log.Println(t, string(b))
@@ -68,11 +59,11 @@ func main() {
 
 	http.Handle("/engine.io/", server)
 	http.Handle("/", http.FileServer(http.Dir("./asset")))
-	log.Println("Serving at localhost:5000...")
+	log.Println("serving at localhost:5000...")
 	log.Fatal(http.ListenAndServe(":5000", nil))
 }
 ```
 
 ## License
 
-The 3-clause BSD License  - see LICENSE for more details
+3-clause BSD — see [LICENSE](../LICENSE) for details.

--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -8,132 +8,76 @@ package main
 // Bring up a pair of browsers and chat between them.
 //
 
-//
-// Notes
-//
-// 1. Updated to use current jQuery 3.1.5 -- Sun May 10 06:45:52 MDT 2020
-//
-
 import (
 	"flag"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
-	"strings"
-
-	"runtime"
 
 	"github.com/taigrr/socketio"
 )
 
-var Port = flag.String("port", "9000", "Port to listen to")                           // 0
-var HostIP = flag.String("host", "localhost", "Host name or IP address to listen on") // 1
-var Dir = flag.String("dir", "./asset", "Directory where files are served from")      // 2
-var Debug = flag.String("debug", "", "Comma separated list of debug flags")           // 3
+var Port = flag.String("port", "9000", "Port to listen to")
+var HostIP = flag.String("host", "localhost", "Host name or IP address to listen on")
+var Dir = flag.String("dir", "./asset", "Directory where files are served from")
+
 func init() {
-	flag.StringVar(Port, "P", "9000", "Port to listen to")                           // 0
-	flag.StringVar(HostIP, "H", "localhost", "Host name or IP address to listen on") // 1
-	flag.StringVar(Dir, "d", "./asset", "Direcotry where files are served from")     // 2
-}
-
-func Usage() {
-	fmt.Printf(`
-Compile and run server with:
-
-$ go run main.go [ -P | --port #### ] [ -H | --host IP-Host ] [ -d | --dir Path-To-Assets ]
-
--P | --port        Port number.  Default 9000
--H | --host        Host to listen on.  Default 'localhost' but can be an IP or 0.0.0.0 for
-                   IP addresses on this system.
--d | --dir         Directory to serve with files.  Default ./asset.
---debug            Debug flags 
-
-`)
-}
-
-var DebugFlag = make(map[string]bool)
-
-func callerInfo() string {
-	_, file, line, ok := runtime.Caller(1)
-	if !ok {
-		return "unknown"
-	}
-	return fmt.Sprintf("%s:%d", file, line)
+	flag.StringVar(Port, "P", "9000", "Port to listen to")
+	flag.StringVar(HostIP, "H", "localhost", "Host name or IP address to listen on")
+	flag.StringVar(Dir, "d", "./asset", "Directory where files are served from")
 }
 
 func main() {
-
 	flag.Parse()
 	fns := flag.Args()
 
 	if len(fns) != 0 {
 		fmt.Printf("Usage: Invalid arguments supplied, %s\n", fns)
-		Usage()
+		flag.Usage()
 		os.Exit(1)
 	}
 
-	var host_ip string = ""
+	var hostIP string
 	if *HostIP != "localhost" {
-		host_ip = *HostIP
+		hostIP = *HostIP
 	}
-
-	if *Debug != "" {
-		for _, s := range strings.Split(*Debug, ",") {
-			DebugFlag[s] = true
-		}
-		// Debug flags removed (legacy pschlump debug system)
-	}
-
-	// Make certain that the command line parameters are handled correctly
-	// fmt.Printf("host_ip >%s< HostIP >%s< Port >%s<\n", host_ip, *HostIP, *Port)
 
 	server, err := socketio.NewServer(nil)
 	if err != nil {
-		log.Fatal(fmt.Errorf("creating socket.io server at %s: %w", callerInfo(), err))
+		log.Fatalf("creating socket.io server: %v", err)
 	}
 
-	// connection ->
-	//	new messsage -> brodcast "chat message"
-	//  disconnect
-	//  add user -> login
-	//  typing -> ???
-	//  stop typing -> ???
-
 	server.On("connection", func(so socketio.Socket) {
-		fmt.Printf("%sa user connected%s, %s\n", "MiscLib.ColorGreen33[32m", "MiscLib.ColorReset33[0m", callerInfo())
+		log.Println("user connected")
 		so.Join("chat")
-		//so.On("chat message", func(msg string) {
-		//	fmt.Printf("%schat message, %s%s, %s\n", "MiscLib.ColorGreen33[32m", msg, "MiscLib.ColorReset33[0m", callerInfo())
-		//	so.BroadcastTo("chat", "chat message", msg)
-		//})
+
 		so.On("new message", func(msg string) {
-			fmt.Printf("%schat message: -->>%s<<--%s, %s\n", "MiscLib.ColorGreen33[32m", msg, "MiscLib.ColorReset33[0m", callerInfo())
+			log.Printf("chat message: %s", msg)
 			so.BroadcastTo("chat", "chat message", msg)
 		})
 		so.On("disconnect", func() {
-			fmt.Printf("%suser disconnect%s, %s\n", "MiscLib.ColorYellow33[33m", "MiscLib.ColorReset33[0m", callerInfo())
+			log.Println("user disconnected")
 		})
 		so.On("add user", func() {
-			fmt.Printf("%sadd user%s, %s\n", "MiscLib.ColorRed33[31m", "MiscLib.ColorReset33[0m", callerInfo())
-			so.Emit("login", fmt.Sprintf("Hello %s", "xyzzy"))
+			log.Println("add user")
+			so.Emit("login", "Hello")
 		})
-
 		so.On("typing", func() {
-			fmt.Printf("%styping%s, %s\n", "MiscLib.ColorRed33[31m", "MiscLib.ColorReset33[0m", callerInfo())
+			log.Println("typing")
 		})
 		so.On("stop typing", func() {
-			fmt.Printf("%sstop typing%s, %s\n", "MiscLib.ColorRed33[31m", "MiscLib.ColorReset33[0m", callerInfo())
+			log.Println("stop typing")
 		})
 	})
 
 	server.On("error", func(so socketio.Socket, err error) {
-		fmt.Printf("Error: %s, %s\n", err, callerInfo())
+		log.Printf("error: %v", err)
 	})
 
 	http.Handle("/socket.io/", server)
 	http.Handle("/", http.FileServer(http.Dir(*Dir)))
+	listen := fmt.Sprintf("%s:%s", hostIP, *Port)
 	fmt.Printf("Serving on port %s, browse to http://localhost:%s/\n", *Port, *Port)
-	listen := fmt.Sprintf("%s:%s", host_ip, *Port)
 	log.Fatal(http.ListenAndServe(listen, nil))
 }


### PR DESCRIPTION
## Changes

- **README.md**: Replaced stale import paths (mlsquires, pschlump, googollee) with `taigrr/socketio`. Simplified the example code to a clean, minimal chat server. Added pkg.go.dev badge. Removed outdated FAQ and verbose history section.
- **engineio/README.md**: Updated all import paths to `taigrr/socketio/engineio`. Replaced deprecated `ioutil.ReadAll` with `io.ReadAll` in example. Added pkg.go.dev badge. Removed stale Travis CI badge.
- **examples/chat/main.go**: Removed hardcoded ANSI escape string literals (`MiscLib.ColorGreen33[32m` etc.) — now uses standard `log` output. Removed unused `runtime` and `strings` imports. Fixed typos in flag descriptions. Cleaned up variable naming (`host_ip` → `hostIP`).