### PR TITLE
fix(ack): propagate send errors

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -87,7 +87,7 @@ func (s *socket) sendID(args []interface{}) (int, error) {
 	encoder := newEncoder(s.conn)
 	err := encoder.Encode(p)
 	if err != nil {
-		return -1, nil
+		return -1, err
 	}
 	return p.ID, nil
 }

--- a/socket_test.go
+++ b/socket_test.go
@@ -1,0 +1,49 @@
+package socketio
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/taigrr/socketio/engineio"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type failingConn struct {
+	nextWriterErr error
+}
+
+func (c *failingConn) Id() string {
+	return "test"
+}
+
+func (c *failingConn) Request() *http.Request {
+	return nil
+}
+
+func (c *failingConn) Close() error {
+	return nil
+}
+
+func (c *failingConn) NextReader() (engineio.MessageType, io.ReadCloser, error) {
+	return engineio.MessageText, nil, io.EOF
+}
+
+func (c *failingConn) NextWriter(engineio.MessageType) (io.WriteCloser, error) {
+	return nil, c.nextWriterErr
+}
+
+func TestSendIDPropagatesEncoderError(t *testing.T) {
+	Convey("sendID returns encoder errors and preserves the ack counter", t, func() {
+		wantErr := errors.New("writer unavailable")
+		socketConn := &failingConn{nextWriterErr: wantErr}
+		serverSocket := newSocket(socketConn, newBaseHandler("", newBroadcastDefault()))
+
+		id, err := serverSocket.sendID([]interface{}{"event", "payload"})
+		So(id, ShouldEqual, -1)
+		So(err, ShouldEqual, wantErr)
+		So(serverSocket.id, ShouldEqual, 1)
+	})
+}


### PR DESCRIPTION
## Summary
- propagate encoder failures from socket.sendID instead of silently returning success
- add a regression test covering failed ack sends

## Testing
- go test ./...
- go test -race ./...
- staticcheck ./...
