### PR TITLE
fix(handler): initialize extended handler maps

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -24,10 +24,12 @@ type baseHandler struct {
 
 func newBaseHandler(name string, broadcast BroadcastAdaptor) *baseHandler {
 	return &baseHandler{
-		events:    make(map[string]*caller),
-		allEvents: make([]*caller, 0, 5),
-		name:      name,
-		broadcast: broadcast,
+		events:     make(map[string]*caller),
+		allEvents:  make([]*caller, 0, 5),
+		xEvents:    make(map[string]EventHandlerFunc),
+		xAllEvents: make([]EventHandlerFunc, 0, 5),
+		name:       name,
+		broadcast:  broadcast,
 	}
 }
 
@@ -89,13 +91,18 @@ type socketHandler struct {
 
 func newSocketHandler(s *socket, base *baseHandler) *socketHandler {
 	events := make(map[string]*caller)
-	allEvents := make([]*caller, 0, 5)
+	allEvents := make([]*caller, 0, len(base.allEvents))
 	xEvents := make(map[string]EventHandlerFunc)
-	xAllEvents := make([]EventHandlerFunc, 0, 5)
+	xAllEvents := make([]EventHandlerFunc, 0, len(base.xAllEvents))
 	base.lock.Lock()
 	for k, v := range base.events {
 		events[k] = v
 	}
+	allEvents = append(allEvents, base.allEvents...)
+	for k, v := range base.xEvents {
+		xEvents[k] = v
+	}
+	xAllEvents = append(xAllEvents, base.xAllEvents...)
 	base.lock.Unlock()
 	return &socketHandler{
 		baseHandler: &baseHandler{

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,0 +1,45 @@
+package socketio
+
+import "testing"
+
+func TestBaseHandlerHandleInitializesExtendedHandlers(t *testing.T) {
+	handler := newBaseHandler("/", newBroadcastDefault())
+
+	called := false
+	if err := handler.Handle("ping", func(_ *Socket, message string, _ [][]byte) error {
+		called = message == "ping"
+		return nil
+	}); err != nil {
+		t.Fatalf("Handle() error = %v", err)
+	}
+
+	if _, ok := handler.xEvents["ping"]; !ok {
+		t.Fatal("expected extended handler to be registered")
+	}
+	if called {
+		t.Fatal("handler should not be invoked during registration")
+	}
+}
+
+func TestNewSocketHandlerCopiesExtendedHandlers(t *testing.T) {
+	base := newBaseHandler("/", newBroadcastDefault())
+	base.xAllEvents = append(base.xAllEvents, func(_ *Socket, _ string, _ [][]byte) error { return nil })
+
+	if err := base.Handle("ping", func(_ *Socket, message string, _ [][]byte) error {
+		if message != "ping" {
+			t.Fatalf("unexpected message %q", message)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("Handle() error = %v", err)
+	}
+
+	handler := newSocketHandler(&socket{}, base)
+
+	if _, ok := handler.xEvents["ping"]; !ok {
+		t.Fatal("expected socket handler to copy extended handlers")
+	}
+	if len(handler.xAllEvents) != 1 {
+		t.Fatalf("expected 1 xAllEvents handler, got %d", len(handler.xAllEvents))
+	}
+}


### PR DESCRIPTION
## Summary
- initialize xEvents/xAllEvents in newBaseHandler so Handle/HandleAny registration does not panic
- copy extended handler registrations into per-socket handlers
- add regression coverage for extended handler registration and cloning

## Testing
- go test ./...
- go test -race ./...
- staticcheck ./...
