### PR TITLE
test(broadcast): cover room accounting

### DIFF
--- a/broadcast_adapter_test.go
+++ b/broadcast_adapter_test.go
@@ -3,6 +3,7 @@ package socketio
 import (
 	"errors"
 	"net/http"
+	"slices"
 	"testing"
 )
 
@@ -62,5 +63,79 @@ func TestBroadcastSendReturnsEmitError(t *testing.T) {
 
 	if err := adapter.Send(nil, "room", "update"); !errors.Is(err, wantErr) {
 		t.Fatalf("Send error=%v, want %v", err, wantErr)
+	}
+}
+
+func TestBroadcastRoomAccounting(t *testing.T) {
+	adapter := newBroadcastDefault().(*broadcast)
+	alphaOne := &broadcastTestSocket{id: "alpha-1"}
+	alphaTwo := &broadcastTestSocket{id: "alpha-2"}
+	betaOne := &broadcastTestSocket{id: "beta-1"}
+
+	for room, socket := range map[string]*broadcastTestSocket{
+		"alpha": alphaOne,
+		"beta":  betaOne,
+	} {
+		if err := adapter.Join(room, socket); err != nil {
+			t.Fatalf("Join %s: %v", room, err)
+		}
+	}
+	if err := adapter.Join("alpha", alphaTwo); err != nil {
+		t.Fatalf("Join alpha second socket: %v", err)
+	}
+
+	count, err := adapter.NumberInRoom("alpha")
+	if err != nil {
+		t.Fatalf("NumberInRoom alpha: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("NumberInRoom alpha=%d, want 2", count)
+	}
+
+	rooms, err := adapter.ListOfRooms("")
+	if err != nil {
+		t.Fatalf("ListOfRooms: %v", err)
+	}
+	slices.Sort(rooms)
+	if !slices.Equal(rooms, []string{"alpha", "beta"}) {
+		t.Fatalf("ListOfRooms=%v, want [alpha beta]", rooms)
+	}
+
+	roomCount, err := adapter.NumberOfRooms("")
+	if err != nil {
+		t.Fatalf("NumberOfRooms: %v", err)
+	}
+	if roomCount != 2 {
+		t.Fatalf("NumberOfRooms=%d, want 2", roomCount)
+	}
+
+	if err := adapter.Leave("alpha", alphaOne); err != nil {
+		t.Fatalf("Leave alpha first socket: %v", err)
+	}
+	count, err = adapter.NumberInRoom("alpha")
+	if err != nil {
+		t.Fatalf("NumberInRoom alpha after first leave: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("NumberInRoom alpha after first leave=%d, want 1", count)
+	}
+
+	if err := adapter.Leave("alpha", alphaTwo); err != nil {
+		t.Fatalf("Leave alpha second socket: %v", err)
+	}
+	count, err = adapter.NumberInRoom("alpha")
+	if err != nil {
+		t.Fatalf("NumberInRoom alpha after emptying room: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("NumberInRoom alpha after emptying room=%d, want 0", count)
+	}
+
+	rooms, err = adapter.ListOfRooms("")
+	if err != nil {
+		t.Fatalf("ListOfRooms after emptying alpha: %v", err)
+	}
+	if len(rooms) != 1 || rooms[0] != "beta" {
+		t.Fatalf("ListOfRooms after emptying alpha=%v, want [beta]", rooms)
 	}
 }


### PR DESCRIPTION
## Summary
- add coverage for broadcast room join/leave accounting
- verify room listing and room counts stay in sync as members leave
- exercise empty-room cleanup so stale rooms are removed

## Testing
- go test ./...
- go test -race ./...
- staticcheck ./...